### PR TITLE
vshn-lbaas-hieradata: Correctly push feature branch

### DIFF
--- a/modules/vshn-lbaas-hieradata/files/commit-hieradata.sh
+++ b/modules/vshn-lbaas-hieradata/files/commit-hieradata.sh
@@ -41,7 +41,7 @@ fi
 
 if [ "${push}" -eq 1 ]; then
   # Push branch to origin and set upstream
-  git push origin "${branch}"
+  git push origin "${branch}":"${branch}"
 fi
 
 # Always set branch's upstream to origin/master.


### PR DESCRIPTION
Previously, there were cases (e.g. multiple terraform runs with the same local state where the `${branch}` already exists locally) where `git push origin ${branch}` would implicitly push `${branch}` to `master` in the remote hieradata repo. This commit adjusts the push command to always push the local `${branch}` to a matching remote `${branch}`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
