### PR TITLE
vshn-lbaas-hieradata: Render valid hieradata if internal_vip is empty

### DIFF
--- a/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
+++ b/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
@@ -11,7 +11,9 @@ profile_openshift4_gateway::floating_addresses:
   nat: ${nat_vip}
   router: ${router_vip}
 profile_openshift4_gateway::floating_address_provider: cloudscale
+%{ if internal_vip != "" ~}
 profile_openshift4_gateway::internal_vip: ${internal_vip}
+%{ endif ~}
 profile_openshift4_gateway::floating_address_settings:
   token: ${api_secret}
 profile_openshift4_gateway::backends:


### PR DESCRIPTION
Don't add the `profile_openshift4_gateway::internal_vip` key in the resulting hieradata configuration, if variable `internal_vip` is empty

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
