### PR TITLE
Add support for distribution-aware configuration of the LBs

### DIFF
--- a/modules/vshn-lbaas-cloudscale/hiera.tf
+++ b/modules/vshn-lbaas-cloudscale/hiera.tf
@@ -6,6 +6,8 @@ module "hiera" {
   bootstrap_node           = var.bootstrap_node
   node_name_suffix         = var.node_name_suffix
   cluster_id               = var.cluster_id
+  distribution             = var.distribution
+  ingress_controller       = var.ingress_controller
   lb_names                 = random_id.lb[*].hex
   lb_cloudscale_api_secret = var.lb_cloudscale_api_secret
   hieradata_repo_user      = var.hieradata_repo_user

--- a/modules/vshn-lbaas-cloudscale/variables.tf
+++ b/modules/vshn-lbaas-cloudscale/variables.tf
@@ -8,6 +8,18 @@ variable "cluster_id" {
   description = "ID of the cluster"
 }
 
+variable "distribution" {
+  type        = string
+  description = "The K8s distribution running on the cluster"
+  default     = ""
+}
+
+variable "ingress_controller" {
+  type        = string
+  description = "The ingress controller running on the cluster"
+  default     = ""
+}
+
 variable "region" {
   type        = string
   description = "Region where to deploy nodes"

--- a/modules/vshn-lbaas-hieradata/main.tf
+++ b/modules/vshn-lbaas-hieradata/main.tf
@@ -19,13 +19,15 @@ resource "local_file" "lb_hieradata" {
   content = templatefile(
     "${path.module}/templates/hieradata.yaml.tmpl",
     {
-      "cluster_id"   = var.cluster_id
-      "api_secret"   = var.lb_cloudscale_api_secret
-      "api_vip"      = var.api_vip
-      "internal_vip" = var.internal_vip
-      "nat_vip"      = var.nat_vip
-      "router_vip"   = var.router_vip
-      "nodes"        = local.instance_fqdns
+      "cluster_id"         = var.cluster_id
+      "distribution"       = var.distribution
+      "ingress_controller" = var.ingress_controller
+      "api_secret"         = var.lb_cloudscale_api_secret
+      "api_vip"            = var.api_vip
+      "internal_vip"       = var.internal_vip
+      "nat_vip"            = var.nat_vip
+      "router_vip"         = var.router_vip
+      "nodes"              = local.instance_fqdns
       "backends" = {
         "api"    = var.api_backends[*]
         "router" = var.router_backends[*],

--- a/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
+++ b/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
@@ -1,4 +1,10 @@
 # Managed by Terraform for Project Syn cluster ${cluster_id}
+%{ if distribution != "" ~}
+profile_openshift4_gateway::distribution: ${distribution}
+%{ endif ~}
+%{ if ingress_controller != "" ~}
+profile_openshift4_gateway::ingress_controller: ${ingress_controller}
+%{ endif ~}
 profile_openshift4_gateway::nodes:
 %{ for node in nodes ~}
   - ${node}

--- a/modules/vshn-lbaas-hieradata/variables.tf
+++ b/modules/vshn-lbaas-hieradata/variables.tf
@@ -24,6 +24,18 @@ variable "cluster_id" {
   description = "ID of the cluster"
 }
 
+variable "distribution" {
+  type        = string
+  description = "The K8s distribution running on the cluster"
+  default     = ""
+}
+
+variable "ingress_controller" {
+  type        = string
+  description = "The ingress controller running on the cluster"
+  default     = ""
+}
+
 variable "lb_names" {
   description = "The hostnames of the loadbalancers"
   type        = list(string)


### PR DESCRIPTION
This allows users to make use of the new parameters in `profile_openshift4_gateway` which allows selecting a K8s distribution and ingress controller for which the LBs should be configured.

See https://git.vshn.net/vshn-puppet/profile_openshift4_gateway/-/merge_requests/5 for the puppet profile MR.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
