### PR TITLE
vshn-lbaas-cloudscale: Don't use `-o pipefail` in /bin/sh script

### DIFF
--- a/modules/vshn-lbaas-cloudscale/files/register-server.sh
+++ b/modules/vshn-lbaas-cloudscale/files/register-server.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eo pipefail
+set -ex
 
 curl -s -X POST -H "X-AccessToken: ${CONTROL_VSHN_NET_TOKEN}" \
   https://control.vshn.net/api/servers/1/appuio/ \


### PR DESCRIPTION
`/bin/sh` (usually dash) doesn't support `-o pipefail`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
