### PR TITLE
Specify puppet environment on first run

### DIFF
--- a/modules/vshn-lbaas-cloudscale/main.tf
+++ b/modules/vshn-lbaas-cloudscale/main.tf
@@ -70,7 +70,7 @@ locals {
       "mkdir -p /etc/puppetlabs/facter/facts.d",
       "netplan apply",
       ["bash", "-c",
-      "set +e -x; for ((i=0; i < 3; ++i)); do /opt/puppetlabs/bin/puppet facts && break; done; for ((i=0; i < 3; ++i)); do /opt/puppetlabs/bin/puppet agent -t --server master.puppet.vshn.net && break; done"],
+      "set +e -x; for ((i=0; i < 3; ++i)); do /opt/puppetlabs/bin/puppet facts && break; done; for ((i=0; i < 3; ++i)); do /opt/puppetlabs/bin/puppet agent -t --server master.puppet.vshn.net --environment AppuioLbaas && break; done"],
       "sleep 5",
       "shutdown --reboot +1 'Reboot for system setup'",
     ],


### PR DESCRIPTION
As described in in VSHNOPS-3495, with Puppet 6.25.0, the agent does not make a node definition request to the server to find out the correct environment to run in.  This means we need to explicitly set the environment on the first run.


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
