### PR TITLE
Make `vshn-lbaas-hieradata` support multiple cloud providers

### DIFF
--- a/modules/vshn-lbaas-cloudscale/hiera.tf
+++ b/modules/vshn-lbaas-cloudscale/hiera.tf
@@ -6,20 +6,28 @@ module "hiera" {
 
   source = "../vshn-lbaas-hieradata"
 
-  api_backends             = local.api_backends
-  router_backends          = var.router_backends
-  bootstrap_node           = var.bootstrap_node
-  node_name_suffix         = var.node_name_suffix
-  cluster_id               = var.cluster_id
-  distribution             = var.distribution
-  ingress_controller       = var.ingress_controller
-  lb_names                 = random_id.lb[*].hex
-  lb_cloudscale_api_secret = var.lb_cloudscale_api_secret
-  hieradata_repo_user      = var.hieradata_repo_user
-  api_vip                  = cidrhost(cloudscale_floating_ip.api_vip[0].network, 0)
-  internal_vip             = var.internal_vip
-  nat_vip                  = cidrhost(cloudscale_floating_ip.nat_vip[0].network, 0)
-  router_vip               = cidrhost(cloudscale_floating_ip.router_vip[0].network, 0)
-  team                     = var.team
-  enable_proxy_protocol    = var.enable_proxy_protocol
+  cloud_provider = "cloudscale"
+
+  api_backends          = local.api_backends
+  router_backends       = var.router_backends
+  bootstrap_node        = var.bootstrap_node
+  node_name_suffix      = var.node_name_suffix
+  cluster_id            = var.cluster_id
+  distribution          = var.distribution
+  ingress_controller    = var.ingress_controller
+  lb_names              = random_id.lb[*].hex
+  hieradata_repo_user   = var.hieradata_repo_user
+  api_vip               = cidrhost(cloudscale_floating_ip.api_vip[0].network, 0)
+  internal_vip          = var.internal_vip
+  nat_vip               = cidrhost(cloudscale_floating_ip.nat_vip[0].network, 0)
+  router_vip            = cidrhost(cloudscale_floating_ip.router_vip[0].network, 0)
+  team                  = var.team
+  enable_proxy_protocol = var.enable_proxy_protocol
+
+  lb_api_credentials = {
+    cloudscale = {
+      secret = var.lb_cloudscale_api_secret
+    }
+    exoscale = null
+  }
 }

--- a/modules/vshn-lbaas-hieradata/README.md
+++ b/modules/vshn-lbaas-hieradata/README.md
@@ -12,18 +12,20 @@ The Terraform module in this repository generates, pushes, and opens MRs for APP
 
 The module provides variables to
 
-* specify the cluster's id, base domain, SSH key, router backends, bootstrap node.
+* specify the cloud provider for which the hieradata should be generated
+* specify the cluster's id, base domain, SSH key, api backends, router backends, bootstrap node.
 * specify virtual ips for:
   * the Kubernetes/OpenShift API in the internal network
   * the Kubernetes/OpenShift API
   * the source IP for the cluster's NATed egress traffic
   * the cluster's ingress controller/application router
-* specify a cloudscale.ch API secret for Floaty
+* specify cloud provider credentials for Floaty.
+  The module currently supports cloudscale.ch and Exoscale.
 * specify the username for the APPUiO hieradata Git repository (see next sections for details).
 
 ## Required credentials
 
-* A read/write cloudscale.ch API token in the project in which the cluster should be deployed for Floaty
+* Floaty credentials for the selected cloud provider, see the [Floaty README](https://github.com/vshn/floaty/#configuration) for details.
 * A project access token for the APPUiO hieradata repository must be created on [git.vshn.net](https://git.vshn.net/appuio/appuio_hieradata/-/settings/access_tokens)
   * The minimum required permissions for the project access token are `api` (to create MRs), `read_repository` (to clone the repo) and `write_repository` (to push to the repo).
 

--- a/modules/vshn-lbaas-hieradata/main.tf
+++ b/modules/vshn-lbaas-hieradata/main.tf
@@ -3,8 +3,7 @@ locals {
 
   lb_count = length(var.lb_names)
 
-  api_key    = var.cloud_provider == "exoscale" ? var.lb_api_credentials.exoscale.key : ""
-  api_secret = var.cloud_provider == "exoscale" ? var.lb_api_credentials.exoscale.secret : var.lb_api_credentials.cloudscale.secret
+  api_credentials = var.cloud_provider == "cloudscale" ? var.lb_api_credentials.cloudscale : var.lb_api_credentials.exoscale
 
   public_interface   = var.cloud_provider == "cloudscale" ? "ens3" : "eth0"
   private_interfaces = var.cloud_provider == "cloudscale" ? ["ens4"] : ["eth1"]
@@ -29,8 +28,7 @@ resource "local_file" "lb_hieradata" {
       "cluster_id"         = var.cluster_id
       "distribution"       = var.distribution
       "ingress_controller" = var.ingress_controller
-      "api_key"            = local.api_key
-      "api_secret"         = local.api_secret
+      "api_credentials"    = local.api_credentials
       "api_vip"            = var.api_vip
       "internal_vip"       = var.internal_vip
       "nat_vip"            = var.nat_vip

--- a/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
+++ b/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
@@ -25,7 +25,9 @@ profile_openshift4_gateway::floating_address_provider: ${cloud_provider}
 profile_openshift4_gateway::internal_vip: ${internal_vip}
 %{ endif ~}
 profile_openshift4_gateway::floating_address_settings:
-  token: ${api_secret}
+%{ for k, v in api_credentials ~}
+  ${k}: ${v}
+%{ endfor ~}
 profile_openshift4_gateway::backends:
   'api':%{ if length(backends["api"]) == 0 && bootstrap_node == "" } []%{ endif }
 %{ for be in backends["api"] ~}

--- a/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
+++ b/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
@@ -9,12 +9,16 @@ profile_openshift4_gateway::nodes:
 %{ for node in nodes ~}
   - ${node}
 %{ endfor ~}
-profile_openshift4_gateway::public_interface: ens3
+profile_openshift4_gateway::public_interface: ${public_interface}
 profile_openshift4_gateway::private_interfaces:
-  - ens4
+%{ for if in private_interfaces ~}
+  - ${if}
+%{ endfor ~}
 profile_openshift4_gateway::floating_addresses:
   api: ${api_vip}
+%{ if nat_vip != "" ~}
   nat: ${nat_vip}
+%{ endif ~}
   router: ${router_vip}
 profile_openshift4_gateway::floating_address_provider: cloudscale
 %{ if internal_vip != "" ~}

--- a/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
+++ b/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
@@ -20,7 +20,7 @@ profile_openshift4_gateway::floating_addresses:
   nat: ${nat_vip}
 %{ endif ~}
   router: ${router_vip}
-profile_openshift4_gateway::floating_address_provider: cloudscale
+profile_openshift4_gateway::floating_address_provider: ${cloud_provider}
 %{ if internal_vip != "" ~}
 profile_openshift4_gateway::internal_vip: ${internal_vip}
 %{ endif ~}

--- a/modules/vshn-lbaas-hieradata/variables.tf
+++ b/modules/vshn-lbaas-hieradata/variables.tf
@@ -1,3 +1,13 @@
+variable "cloud_provider" {
+  type        = string
+  description = "The cloud provider to generate the hieradata for."
+
+  validation {
+    condition     = var.cloud_provider == "cloudscale" || var.cloud_provider == "exoscale"
+    error_message = "The vshn-lbaas-hieradata module currently only supports cloudscale.ch and Exoscale."
+  }
+}
+
 variable "router_backends" {
   type        = list(string)
   description = "IP addresses or hostnames of nodes running ingress routers"
@@ -41,9 +51,22 @@ variable "lb_names" {
   type        = list(string)
 }
 
-variable "lb_cloudscale_api_secret" {
-  type        = string
-  description = "Read/Write API secret for Floaty"
+variable "lb_api_credentials" {
+  type = object({
+    cloudscale = optional(object({
+      secret = string,
+    })),
+    exoscale = optional(object({
+      key    = string,
+      secret = string,
+    }))
+  })
+  description = "API credentials for Floaty."
+
+  validation {
+    condition     = var.lb_api_credentials.cloudscale != null || var.lb_api_credentials.exoscale != null
+    error_message = "You *MUST* configure either cloudscale.ch or Exoscale API credentials."
+  }
 }
 
 variable "hieradata_repo_user" {


### PR DESCRIPTION
* Remove hardcoded logic for cloudscale.ch
* Add scaffolding for Exoscale

Note: this PR also updates `vshn-lbaas-cloudscale` to use the new interface for `vshn-lbaas-hieradata`, so this is not a breaking change for users of `vshn-lbaas-cloudscale`.

Prerequisite for #18 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
