### PR TITLE
Add PTR record for cloudscale VIPs

### DIFF
--- a/modules/vshn-lbaas-cloudscale/main.tf
+++ b/modules/vshn-lbaas-cloudscale/main.tf
@@ -2,6 +2,7 @@ resource "cloudscale_floating_ip" "api_vip" {
   count       = var.lb_count != 0 ? 1 : 0
   ip_version  = 4
   region_slug = var.region
+  reverse_ptr = "api.${var.node_name_suffix}"
 
   lifecycle {
     ignore_changes = [
@@ -16,6 +17,7 @@ resource "cloudscale_floating_ip" "router_vip" {
   count       = var.lb_count != 0 ? 1 : 0
   ip_version  = 4
   region_slug = var.region
+  reverse_ptr = "ingress.${var.node_name_suffix}"
 
   lifecycle {
     ignore_changes = [
@@ -30,6 +32,7 @@ resource "cloudscale_floating_ip" "nat_vip" {
   count       = var.lb_count != 0 ? 1 : 0
   ip_version  = 4
   region_slug = var.region
+  reverse_ptr = "egress.${var.node_name_suffix}"
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
This adds PTR records for all cloudscale VIPs. I decided to use `ingress.`, `egress.`, and `api.` as this currently seems to be the most likely setup used in [OCP-301 (internal)](https://ticket.vshn.net/browse/OCP-301)


closes https://github.com/appuio/terraform-modules/issues/12
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
