### PR TITLE
vshn-lbaas-exoscale: Update module for Exoscale provider v0.41.0

### DIFF
--- a/modules/vshn-lbaas-exoscale/README.md
+++ b/modules/vshn-lbaas-exoscale/README.md
@@ -59,7 +59,7 @@ To configure the LBs for such a cluster, provide the following input:
 ```
 cluster_network = {
   enabled           = true
-  name              = exoscale_network.<resource>.name
+  name              = exoscale_private_network.<resource>.name
   internal_vip_host = "100"
 }
 ```

--- a/modules/vshn-lbaas-exoscale/hiera.tf
+++ b/modules/vshn-lbaas-exoscale/hiera.tf
@@ -5,7 +5,7 @@ locals {
   internal_vip = var.cluster_network.enabled ? (
     cidrhost(local.network_cidr, var.cluster_network.internal_vip_host)
   ) : ""
-  nat_vip = var.cluster_network.enabled ? exoscale_ipaddress.nat[0].ip_address : ""
+  nat_vip = var.cluster_network.enabled ? exoscale_elastic_ip.nat[0].ip_address : ""
 }
 module "hiera" {
   count = var.lb_count > 0 ? 1 : 0
@@ -23,10 +23,10 @@ module "hiera" {
   ingress_controller    = var.ingress_controller
   lb_names              = random_id.lb[*].hex
   hieradata_repo_user   = var.hieradata_repo_user
-  api_vip               = exoscale_ipaddress.api.ip_address
+  api_vip               = exoscale_elastic_ip.api.ip_address
   internal_vip          = local.internal_vip
   nat_vip               = ""
-  router_vip            = exoscale_ipaddress.ingress.ip_address
+  router_vip            = exoscale_elastic_ip.ingress.ip_address
   team                  = var.team
   enable_proxy_protocol = var.enable_proxy_protocol
 

--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -19,30 +19,28 @@ resource "exoscale_network" "lbnet" {
   netmask      = cidrnetmask(local.lbnet_cidr)
 }
 
-resource "exoscale_ipaddress" "api" {
+resource "exoscale_elastic_ip" "api" {
   zone        = var.region
   description = "${var.cluster_id} elastic IP for API"
-  reverse_dns = "api.${var.exoscale_domain_name}."
 }
 resource "exoscale_domain_record" "api" {
   domain      = data.exoscale_domain.cluster.id
   name        = "api"
   ttl         = 60
   record_type = "A"
-  content     = exoscale_ipaddress.api.ip_address
+  content     = exoscale_elastic_ip.api.ip_address
 }
 
-resource "exoscale_ipaddress" "ingress" {
+resource "exoscale_elastic_ip" "ingress" {
   zone        = var.region
   description = "${var.cluster_id} elastic IP for ingress controller"
-  reverse_dns = "ingress.${var.exoscale_domain_name}."
 }
 resource "exoscale_domain_record" "ingress" {
   domain      = data.exoscale_domain.cluster.id
   name        = "ingress"
   ttl         = 60
   record_type = "A"
-  content     = exoscale_ipaddress.ingress.ip_address
+  content     = exoscale_elastic_ip.ingress.ip_address
 }
 resource "exoscale_domain_record" "wildcard" {
   domain      = data.exoscale_domain.cluster.id
@@ -52,11 +50,10 @@ resource "exoscale_domain_record" "wildcard" {
   content     = exoscale_domain_record.ingress.hostname
 }
 
-resource "exoscale_ipaddress" "nat" {
+resource "exoscale_elastic_ip" "nat" {
   count       = var.cluster_network.enabled ? 1 : 0
   zone        = var.region
   description = "${var.cluster_id} elastic IP for NAT gateway"
-  reverse_dns = "egress.${var.exoscale_domain_name}."
 }
 resource "exoscale_domain_record" "egress" {
   count       = var.cluster_network.enabled ? 1 : 0
@@ -64,7 +61,7 @@ resource "exoscale_domain_record" "egress" {
   name        = "egress"
   ttl         = 60
   record_type = "A"
-  content     = exoscale_ipaddress.nat[0].ip_address
+  content     = exoscale_elastic_ip.nat[0].ip_address
 }
 
 resource "random_id" "lb" {

--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -123,10 +123,9 @@ locals {
   ]
 }
 
-resource "exoscale_affinity" "lb" {
+resource "exoscale_anti_affinity_group" "lb" {
   name        = "${var.cluster_id}_lb"
   description = "${var.cluster_id} lb nodes"
-  type        = "host anti-affinity"
 }
 
 data "exoscale_compute_template" "ubuntu2004" {
@@ -184,7 +183,7 @@ resource "exoscale_compute" "lb" {
     [exoscale_security_group.load_balancers.id]
   )
   affinity_group_ids = concat(
-    [exoscale_affinity.lb.id],
+    [exoscale_anti_affinity_group.lb.id],
     var.additional_affinity_group_ids
   )
 

--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -25,7 +25,7 @@ resource "exoscale_ipaddress" "api" {
   reverse_dns = "api.${var.exoscale_domain_name}."
 }
 resource "exoscale_domain_record" "api" {
-  domain      = data.exoscale_domain.cluster.name
+  domain      = data.exoscale_domain.cluster.id
   name        = "api"
   ttl         = 60
   record_type = "A"
@@ -38,14 +38,14 @@ resource "exoscale_ipaddress" "ingress" {
   reverse_dns = "ingress.${var.exoscale_domain_name}."
 }
 resource "exoscale_domain_record" "ingress" {
-  domain      = data.exoscale_domain.cluster.name
+  domain      = data.exoscale_domain.cluster.id
   name        = "ingress"
   ttl         = 60
   record_type = "A"
   content     = exoscale_ipaddress.ingress.ip_address
 }
 resource "exoscale_domain_record" "wildcard" {
-  domain      = data.exoscale_domain.cluster.name
+  domain      = data.exoscale_domain.cluster.id
   name        = "*.apps"
   ttl         = 60
   record_type = "CNAME"
@@ -60,7 +60,7 @@ resource "exoscale_ipaddress" "nat" {
 }
 resource "exoscale_domain_record" "egress" {
   count       = var.cluster_network.enabled ? 1 : 0
-  domain      = data.exoscale_domain.cluster.name
+  domain      = data.exoscale_domain.cluster.id
   name        = "egress"
   ttl         = 60
   record_type = "A"
@@ -252,7 +252,7 @@ resource "exoscale_nic" "additional_network" {
 
 resource "exoscale_domain_record" "lb" {
   count       = var.lb_count
-  domain      = data.exoscale_domain.cluster.name
+  domain      = data.exoscale_domain.cluster.id
   name        = random_id.lb[count.index].hex
   ttl         = 600
   record_type = "A"

--- a/modules/vshn-lbaas-exoscale/outputs.tf
+++ b/modules/vshn-lbaas-exoscale/outputs.tf
@@ -1,9 +1,9 @@
 output "api_vip" {
-  value = exoscale_ipaddress.api.ip_address
+  value = exoscale_elastic_ip.api.ip_address
 }
 
 output "router_vip" {
-  value = exoscale_ipaddress.ingress.ip_address
+  value = exoscale_elastic_ip.ingress.ip_address
 }
 
 output "server_names" {

--- a/modules/vshn-lbaas-exoscale/outputs.tf
+++ b/modules/vshn-lbaas-exoscale/outputs.tf
@@ -11,11 +11,11 @@ output "server_names" {
 }
 
 output "private_ipv4_addresses" {
-  value = exoscale_nic.lb[*].ip_address
+  value = exoscale_compute_instance.lb[*].network_interface[*].ip_address
 }
 
 output "public_ipv4_addresses" {
-  value = exoscale_compute.lb[*].ip_address
+  value = exoscale_compute_instance.lb[*].public_ip_address
 }
 
 output "hieradata_mr_url" {

--- a/modules/vshn-lbaas-exoscale/providers.tf
+++ b/modules/vshn-lbaas-exoscale/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     exoscale = {
       source  = "exoscale/exoscale"
-      version = ">= 0.30"
+      version = "0.41.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/vshn-lbaas-exoscale/security_groups.tf
+++ b/modules/vshn-lbaas-exoscale/security_groups.tf
@@ -1,32 +1,79 @@
+locals {
+  # security group rules to create for TCP and UDP over IPv4 and IPv6
+  open_ports = {
+    "Kubernetes API"           = "6443",
+    "Ingress controller HTTP"  = "80",
+    "Ingress controller HTTPS" = "443",
+  }
+}
+
 resource "exoscale_security_group" "load_balancers" {
   name        = "${var.cluster_id}_load_balancers"
   description = "${var.cluster_id} load balancer VMs"
 }
 
-resource "exoscale_security_group_rules" "load_balancers" {
-  security_group = exoscale_security_group.load_balancers.name
-  ingress {
-    description = "Kubernetes API"
-    protocol    = "TCP"
-    ports       = ["6443"]
-    cidr_list   = ["0.0.0.0/0", "::/0"]
-  }
-  ingress {
-    description = "Ingress controller TCP"
-    protocol    = "TCP"
-    ports       = ["80", "443"]
-    cidr_list   = ["0.0.0.0/0", "::/0"]
-  }
-  ingress {
-    description = "Ingress controller UDP"
-    protocol    = "UDP"
-    ports       = ["80", "443"]
-    cidr_list   = ["0.0.0.0/0", "::/0"]
-  }
-  ingress {
-    description              = "Machine Config server"
-    protocol                 = "TCP"
-    ports                    = ["22623"]
-    user_security_group_list = var.cluster_security_group_names
-  }
+resource "exoscale_security_group_rule" "load_balancers_tcp4" {
+  for_each = local.open_ports
+
+  security_group_id = exoscale_security_group.load_balancers.id
+
+  type        = "INGRESS"
+  description = "${each.key} TCPv4"
+  protocol    = "TCP"
+  start_port  = each.value
+  end_port    = each.value
+  cidr        = "0.0.0.0/0"
+}
+
+resource "exoscale_security_group_rule" "load_balancers_tcp6" {
+  for_each = local.open_ports
+
+  security_group_id = exoscale_security_group.load_balancers.id
+
+  type        = "INGRESS"
+  description = "${each.key} TCPv6"
+  protocol    = "TCP"
+  start_port  = each.value
+  end_port    = each.value
+  cidr        = "::/0"
+}
+
+resource "exoscale_security_group_rule" "load_balancers_udp4" {
+  for_each = local.open_ports
+
+  security_group_id = exoscale_security_group.load_balancers.id
+
+  type        = "INGRESS"
+  description = "${each.key} UDPv4"
+  protocol    = "UDP"
+  start_port  = each.value
+  end_port    = each.value
+  cidr        = "0.0.0.0/0"
+}
+
+resource "exoscale_security_group_rule" "load_balancers_udp6" {
+  for_each = local.open_ports
+
+  security_group_id = exoscale_security_group.load_balancers.id
+
+  type        = "INGRESS"
+  description = "${each.key} UDPv6"
+  protocol    = "UDP"
+  start_port  = each.value
+  end_port    = each.value
+  cidr        = "::/0"
+}
+
+resource "exoscale_security_group_rule" "load_balancers_machine_config_server" {
+  count = length(data.exoscale_security_group.cluster)
+
+  security_group_id = exoscale_security_group.load_balancers.id
+
+  type        = "INGRESS"
+  description = "Machine Config server from ${data.exoscale_security_group.cluster[count.index].name}"
+  protocol    = "TCP"
+  start_port  = "22623"
+  end_port    = "22623"
+
+  user_security_group_id = data.exoscale_security_group.cluster[count.index].id
 }

--- a/modules/vshn-lbaas-exoscale/variables.tf
+++ b/modules/vshn-lbaas-exoscale/variables.tf
@@ -41,7 +41,7 @@ variable "region" {
 
 variable "cluster_security_group_names" {
   type        = list(string)
-  description = "Security group ids for which the LBs should allow traffic on the Machine Config server port"
+  description = "Security group names for which the LBs should allow traffic on the Machine Config server port"
 
   validation {
     condition     = length(var.cluster_security_group_names) > 0


### PR DESCRIPTION
Remove all usages of deprecated Exoscale Terraform resources in the `vshn-lbaas-exoscale` module. This PR requires manual actions to update the Terraform state of existing clusters. Most resources can be migrated by removing the old resource from the state and importing the object using the new resource type. Please see https://github.com/appuio/component-openshift4-terraform/pull/61 for more details and a script which performs the state migration.

Related to https://github.com/appuio/terraform-openshift4-exoscale/issues/59

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.
- [x] Rebase onto main -> make sure we're ready for Terraform >= 1.3.0

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
