### PR TITLE
Remove concluded experiments, bump required version to 1.3

### DIFF
--- a/modules/vshn-lbaas-cloudscale/providers.tf
+++ b/modules/vshn-lbaas-cloudscale/providers.tf
@@ -1,6 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">= 1.3.0"
   required_providers {
     cloudscale = {
       source  = "cloudscale-ch/cloudscale"

--- a/modules/vshn-lbaas-exoscale/providers.tf
+++ b/modules/vshn-lbaas-exoscale/providers.tf
@@ -1,6 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">= 1.3.0"
   required_providers {
     exoscale = {
       source  = "exoscale/exoscale"

--- a/modules/vshn-lbaas-hieradata/providers.tf
+++ b/modules/vshn-lbaas-hieradata/providers.tf
@@ -1,6 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">= 1.3.0"
   required_providers {
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
The experiment "module_variable_optional_attrs" has concluded and is now implemented in Terraform v1.3.
This PR removes the experiment and bumps the minimum required version to 1.3.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
