### PR TITLE
vshn-lbaas-exoscale: Set encdata zone for LB VMs

### DIFF
--- a/modules/vshn-lbaas-exoscale/files/register-server.sh
+++ b/modules/vshn-lbaas-exoscale/files/register-server.sh
@@ -9,6 +9,7 @@ curl -s -X POST -H "X-AccessToken: ${CONTROL_VSHN_NET_TOKEN}" \
     \"fqdn\": \"${SERVER_FQDN}\",
     \"location\": \"exoscale\",
     \"region\": \"${SERVER_REGION}\",
+    \"zone\": \"${SERVER_ZONE}\",
     \"environment\": \"AppuioLbaas\",
     \"project\": \"lbaas\",
     \"role\": \"lb\",


### PR DESCRIPTION
We prepare the zone value in the module, but didn't actually pass it to the control.vshn.net API: https://github.com/appuio/terraform-modules/blob/abc8f485fed9f0534550e19273937593f0ddd40e/modules/vshn-lbaas-exoscale/main.tf#L151-L168

This commit updates the register-server script to also set the zone in the encdata.

Split out from #30 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
