### PR TITLE
vshn-lbaas-exoscale: Generate Floaty IAM API key via Terraform

### DIFF
--- a/modules/vshn-lbaas-exoscale/hiera.tf
+++ b/modules/vshn-lbaas-exoscale/hiera.tf
@@ -46,8 +46,10 @@ module "hiera" {
   lb_api_credentials = {
     cloudscale = null
     exoscale = {
-      key    = exoscale_iam_access_key.floaty.key
-      secret = exoscale_iam_access_key.floaty.secret
+      # Use `nonsensitive` so we get useful apply diffs for the hieradata (if
+      # we already have a copy available locally).
+      key    = nonsensitive(exoscale_iam_access_key.floaty.key)
+      secret = nonsensitive(exoscale_iam_access_key.floaty.secret)
     }
   }
 }

--- a/modules/vshn-lbaas-exoscale/hiera.tf
+++ b/modules/vshn-lbaas-exoscale/hiera.tf
@@ -7,6 +7,19 @@ locals {
   ) : ""
   nat_vip = var.cluster_network.enabled ? exoscale_elastic_ip.nat[0].ip_address : ""
 }
+
+resource "exoscale_iam_access_key" "floaty" {
+  name = "${var.cluster_id}_floaty"
+  operations = [
+    "attach-instance-to-elastic-ip",
+    "detach-instance-from-elastic-ip",
+    "get-instance",
+    "list-instances",
+    "list-private-networks",
+    "get-operation",
+  ]
+}
+
 module "hiera" {
   count = var.lb_count > 0 ? 1 : 0
 
@@ -33,8 +46,8 @@ module "hiera" {
   lb_api_credentials = {
     cloudscale = null
     exoscale = {
-      key    = var.lb_exoscale_api_key
-      secret = var.lb_exoscale_api_secret
+      key    = exoscale_iam_access_key.floaty.key
+      secret = exoscale_iam_access_key.floaty.secret
     }
   }
 }

--- a/modules/vshn-lbaas-exoscale/variables.tf
+++ b/modules/vshn-lbaas-exoscale/variables.tf
@@ -65,16 +65,6 @@ variable "control_vshn_net_token" {
   description = "The token is used to register the server with https://control.vshn.net/"
 }
 
-variable "lb_exoscale_api_key" {
-  type        = string
-  description = "API key for Floaty"
-}
-
-variable "lb_exoscale_api_secret" {
-  type        = string
-  description = "API secret for Floaty"
-}
-
 variable "hieradata_repo_user" {
   type        = string
   description = "User used to check out the hieradata git repo"


### PR DESCRIPTION
We use the newly available `exoscale_iam_access_key` resource to generate an Exoscale API key and secret for Floaty. This allows us to remove the corresponding steps in the install instructions, see https://github.com/appuio/openshift4-docs/pull/208.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
