### PR TITLE
vshn-lbaas-exoscale: Allow users to customize the LB instance type

### DIFF
--- a/modules/vshn-lbaas-exoscale/README.md
+++ b/modules/vshn-lbaas-exoscale/README.md
@@ -21,6 +21,7 @@ The module provides variables to
 
 * control the count of LB VMs.
   Note that we don't recommend changing the count for the LBs from their default values.
+* customize the instance type of the LB VMs (by default we provision "Medium" Exoscale instances).
 * specify the cluster's id, Exoscale region, Exoscale-managed domain name, SSH key, api backends, router backends, and bootstrap node.
 * specify an existing Exoscale managed private network and host for the internal VIP in that network.
 * specify a list of security group ids which are allowed to access the LB's cluster-internal frontends.

--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -174,7 +174,7 @@ resource "exoscale_compute_instance" "lb" {
   ssh_key     = var.ssh_key_name
   zone        = var.region
   template_id = data.exoscale_compute_template.ubuntu2004.id
-  type        = "standard.medium"
+  type        = var.lb_type
   disk_size   = 20
 
   security_group_ids = concat(

--- a/modules/vshn-lbaas-exoscale/variables.tf
+++ b/modules/vshn-lbaas-exoscale/variables.tf
@@ -60,6 +60,12 @@ variable "lb_count" {
   description = "The number of loadbalancers to create"
 }
 
+variable "lb_type" {
+  type        = string
+  default     = "standard.medium"
+  description = "The instance type to use for the LBs"
+}
+
 variable "control_vshn_net_token" {
   type        = string
   description = "The token is used to register the server with https://control.vshn.net/"


### PR DESCRIPTION
This was implemented for cloudscale.ch in #29, this PR ensures that we roughly keep feature parity between the cloudscale.ch and the Exoscale LB modules.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
