### PR TITLE
vshn-lbaas-exoscale: Adjust security group rules to simplify migration of existing clusters

### DIFF
--- a/modules/vshn-lbaas-exoscale/security_groups.tf
+++ b/modules/vshn-lbaas-exoscale/security_groups.tf
@@ -1,10 +1,12 @@
 locals {
   # security group rules to create for TCP and UDP over IPv4 and IPv6
-  open_ports = {
-    "Kubernetes API"           = "6443",
+  open_ports_udp = {
     "Ingress controller HTTP"  = "80",
     "Ingress controller HTTPS" = "443",
   }
+  open_ports_tcp = merge(local.open_ports_udp, {
+    "Kubernetes API" = "6443",
+  })
 }
 
 resource "exoscale_security_group" "load_balancers" {
@@ -13,7 +15,7 @@ resource "exoscale_security_group" "load_balancers" {
 }
 
 resource "exoscale_security_group_rule" "load_balancers_tcp4" {
-  for_each = local.open_ports
+  for_each = local.open_ports_tcp
 
   security_group_id = exoscale_security_group.load_balancers.id
 
@@ -26,7 +28,7 @@ resource "exoscale_security_group_rule" "load_balancers_tcp4" {
 }
 
 resource "exoscale_security_group_rule" "load_balancers_tcp6" {
-  for_each = local.open_ports
+  for_each = local.open_ports_tcp
 
   security_group_id = exoscale_security_group.load_balancers.id
 
@@ -39,7 +41,7 @@ resource "exoscale_security_group_rule" "load_balancers_tcp6" {
 }
 
 resource "exoscale_security_group_rule" "load_balancers_udp4" {
-  for_each = local.open_ports
+  for_each = local.open_ports_udp
 
   security_group_id = exoscale_security_group.load_balancers.id
 
@@ -52,7 +54,7 @@ resource "exoscale_security_group_rule" "load_balancers_udp4" {
 }
 
 resource "exoscale_security_group_rule" "load_balancers_udp6" {
-  for_each = local.open_ports
+  for_each = local.open_ports_udp
 
   security_group_id = exoscale_security_group.load_balancers.id
 

--- a/modules/vshn-lbaas-exoscale/security_groups.tf
+++ b/modules/vshn-lbaas-exoscale/security_groups.tf
@@ -20,7 +20,7 @@ resource "exoscale_security_group_rule" "load_balancers_tcp4" {
   security_group_id = exoscale_security_group.load_balancers.id
 
   type        = "INGRESS"
-  description = "${each.key} TCPv4"
+  description = each.value == "6443" ? "Kubernetes API" : "Ingress controller TCP"
   protocol    = "TCP"
   start_port  = each.value
   end_port    = each.value
@@ -33,7 +33,7 @@ resource "exoscale_security_group_rule" "load_balancers_tcp6" {
   security_group_id = exoscale_security_group.load_balancers.id
 
   type        = "INGRESS"
-  description = "${each.key} TCPv6"
+  description = each.value == "6443" ? "Kubernetes API" : "Ingress controller TCP"
   protocol    = "TCP"
   start_port  = each.value
   end_port    = each.value
@@ -46,7 +46,7 @@ resource "exoscale_security_group_rule" "load_balancers_udp4" {
   security_group_id = exoscale_security_group.load_balancers.id
 
   type        = "INGRESS"
-  description = "${each.key} UDPv4"
+  description = "Ingress controller UDP"
   protocol    = "UDP"
   start_port  = each.value
   end_port    = each.value
@@ -59,7 +59,7 @@ resource "exoscale_security_group_rule" "load_balancers_udp6" {
   security_group_id = exoscale_security_group.load_balancers.id
 
   type        = "INGRESS"
-  description = "${each.key} UDPv6"
+  description = "Ingress controller UDP"
   protocol    = "UDP"
   start_port  = each.value
   end_port    = each.value
@@ -72,7 +72,7 @@ resource "exoscale_security_group_rule" "load_balancers_machine_config_server" {
   security_group_id = exoscale_security_group.load_balancers.id
 
   type        = "INGRESS"
-  description = "Machine Config server from ${data.exoscale_security_group.cluster[count.index].name}"
+  description = "Machine Config server"
   protocol    = "TCP"
   start_port  = "22623"
   end_port    = "22623"


### PR DESCRIPTION
This PR fixes an oversight in #30 where we refactored the security group rules and mistakenly included the Kubernetes API port in the ports to open for UDP traffic. Additionally, the PR ensures that the descriptions for the security group rules don't change, so that we can avoid having to recreate rules when migrating state for existing clusters.

Labeled `ignore` since this PR doesn't need to be included in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
