### PR TITLE
vshn-lbaas-exoscale: Use FQDN as compute instance `name`

### DIFF
--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -170,7 +170,7 @@ data "exoscale_security_group" "cluster" {
 
 resource "exoscale_compute_instance" "lb" {
   count       = var.lb_count
-  name        = random_id.lb[count.index].hex
+  name        = local.instance_fqdns[count.index]
   ssh_key     = var.ssh_key_name
   zone        = var.region
   template_id = data.exoscale_compute_template.ubuntu2004.id


### PR DESCRIPTION
The new Terraform resource `exoscale_compute_instance` doesn't support setting the instance's display name. To ensure we get the instance FQDNs as display names, we use the FQDNs for field `name`. Usually this would configure the instance (through cloud-init) to use its FQDN as its hostname, but we provide a custom cloud-init configuration already which sets the hostname correctly.

Follow-up to #30 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
