### PR TITLE
vshn-lbaas-exoscale: Add support for configuring deployment target ID

### DIFF
--- a/modules/vshn-lbaas-exoscale/README.md
+++ b/modules/vshn-lbaas-exoscale/README.md
@@ -30,6 +30,7 @@ The module provides variables to
 * provide an API token for control.vshn.net (see next sections for details).
 * control whether HAproxy is configured to use PROXY protocol for the router backends
 * provide a list of additional Exoscale private networks to attach to the LBs
+* choose a dedicated deployment target
 
 ## Required credentials
 

--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -186,6 +186,8 @@ resource "exoscale_compute_instance" "lb" {
     var.additional_affinity_group_ids
   )
 
+  deploy_target_id = var.deploy_target_id
+
   # Always configure privnet managed by the module
   # (either clusternet or lb_vrrp)
   network_interface {

--- a/modules/vshn-lbaas-exoscale/variables.tf
+++ b/modules/vshn-lbaas-exoscale/variables.tf
@@ -115,3 +115,9 @@ variable "additional_affinity_group_ids" {
   default     = []
   description = "List of additional affinity group IDs to configure on all lbs"
 }
+
+variable "deploy_target_id" {
+  type        = string
+  default     = ""
+  description = "ID of special deployment target, eg. dedicated hypervisors"
+}


### PR DESCRIPTION
Follow-up to #30. When upgrading the Exoscale Terraform provider, we assumed that we can still pass arbitrary affinity group IDs to instances through `anti_affinity_group_ids`, but that parameter has been changed to only accept anti-affinity groups, while there's a new parameter `deploy_target_id` for other affinity group IDs, such as the one necessary to schedule instances on dedicated hypervisors.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
