### PR TITLE
vshn-lbaas-exoscale: Pass LB security groups by ID

### DIFF
--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -163,11 +163,6 @@ resource "null_resource" "register_lb" {
   }
 }
 
-data "exoscale_security_group" "cluster" {
-  count = length(var.cluster_security_group_names)
-  name  = var.cluster_security_group_names[count.index]
-}
-
 resource "exoscale_compute_instance" "lb" {
   count       = var.lb_count
   name        = local.instance_fqdns[count.index]
@@ -178,7 +173,7 @@ resource "exoscale_compute_instance" "lb" {
   disk_size   = 20
 
   security_group_ids = concat(
-    data.exoscale_security_group.cluster[*].id,
+    var.cluster_security_group_ids,
     [exoscale_security_group.load_balancers.id]
   )
   anti_affinity_group_ids = concat(

--- a/modules/vshn-lbaas-exoscale/outputs.tf
+++ b/modules/vshn-lbaas-exoscale/outputs.tf
@@ -22,8 +22,8 @@ output "hieradata_mr_url" {
   value = module.hiera[*].hieradata_mr_url
 }
 
-output "security_group_name" {
-  value = exoscale_security_group.load_balancers.name
+output "security_group_id" {
+  value = exoscale_security_group.load_balancers.id
 }
 
 output "internal_vip" {

--- a/modules/vshn-lbaas-exoscale/security_groups.tf
+++ b/modules/vshn-lbaas-exoscale/security_groups.tf
@@ -67,7 +67,7 @@ resource "exoscale_security_group_rule" "load_balancers_udp6" {
 }
 
 resource "exoscale_security_group_rule" "load_balancers_machine_config_server" {
-  count = length(data.exoscale_security_group.cluster)
+  count = length(var.cluster_security_group_ids)
 
   security_group_id = exoscale_security_group.load_balancers.id
 
@@ -77,5 +77,5 @@ resource "exoscale_security_group_rule" "load_balancers_machine_config_server" {
   start_port  = "22623"
   end_port    = "22623"
 
-  user_security_group_id = data.exoscale_security_group.cluster[count.index].id
+  user_security_group_id = var.cluster_security_group_ids[count.index]
 }

--- a/modules/vshn-lbaas-exoscale/variables.tf
+++ b/modules/vshn-lbaas-exoscale/variables.tf
@@ -39,13 +39,13 @@ variable "region" {
   description = "Region where to deploy nodes"
 }
 
-variable "cluster_security_group_names" {
+variable "cluster_security_group_ids" {
   type        = list(string)
-  description = "Security group names for which the LBs should allow traffic on the Machine Config server port"
+  description = "Security group ids for which the LBs should allow traffic on the Machine Config server port"
 
   validation {
-    condition     = length(var.cluster_security_group_names) > 0
-    error_message = "You must specify at least one cluster security group."
+    condition     = length(var.cluster_security_group_ids) > 0
+    error_message = "You must specify at least one cluster security group id."
   }
 }
 


### PR DESCRIPTION
When using security group names and looking up associated IDs through data sources, we run into issues with the Exoscale Terraform provider producing inconsistent plans during the initial `terraform apply`.

This commit switches the LB module to directly use security group IDs as inputs and outputs. By doing so, we don't trigger the bugs in the Exoscale Terraform provider.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
