### PR TITLE
vshn-lbaas-exoscale: Switch back to user-provided IAM key for Floaty

### DIFF
--- a/modules/vshn-lbaas-exoscale/hiera.tf
+++ b/modules/vshn-lbaas-exoscale/hiera.tf
@@ -7,19 +7,6 @@ locals {
   ) : ""
   nat_vip = var.cluster_network.enabled ? exoscale_elastic_ip.nat[0].ip_address : ""
 }
-
-resource "exoscale_iam_access_key" "floaty" {
-  name = "${var.cluster_id}_floaty"
-  operations = [
-    "attach-instance-to-elastic-ip",
-    "detach-instance-from-elastic-ip",
-    "get-instance",
-    "list-instances",
-    "list-private-networks",
-    "get-operation",
-  ]
-}
-
 module "hiera" {
   count = var.lb_count > 0 ? 1 : 0
 
@@ -46,10 +33,8 @@ module "hiera" {
   lb_api_credentials = {
     cloudscale = null
     exoscale = {
-      # Use `nonsensitive` so we get useful apply diffs for the hieradata (if
-      # we already have a copy available locally).
-      key    = nonsensitive(exoscale_iam_access_key.floaty.key)
-      secret = nonsensitive(exoscale_iam_access_key.floaty.secret)
+      key    = var.lb_exoscale_api_key
+      secret = var.lb_exoscale_api_secret
     }
   }
 }

--- a/modules/vshn-lbaas-exoscale/variables.tf
+++ b/modules/vshn-lbaas-exoscale/variables.tf
@@ -71,6 +71,16 @@ variable "control_vshn_net_token" {
   description = "The token is used to register the server with https://control.vshn.net/"
 }
 
+variable "lb_exoscale_api_key" {
+  type        = string
+  description = "API key for Floaty"
+}
+
+variable "lb_exoscale_api_secret" {
+  type        = string
+  description = "API secret for Floaty"
+}
+
 variable "hieradata_repo_user" {
   type        = string
   description = "User used to check out the hieradata git repo"


### PR DESCRIPTION
Exoscale's new IAM API (v3) isn't yet supported by the Terraform provider, so we switch back to expecting users to provide the Floaty IAM key as an input variable in the vshn-lbaas-exoscale module.

This reverts #33 (commit a56cbb961f2d14b8d96f602b810e5eaff34fedcf), reversing changes made to 9825ee9bf759232d295f06c01d29fd515939643c.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
