### PR TITLE
vshn-lbaas-exoscale: Manage Elastic IP reverse DNS with Terraform

### DIFF
--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -22,6 +22,7 @@ resource "exoscale_private_network" "lbnet" {
 resource "exoscale_elastic_ip" "api" {
   zone        = var.region
   description = "${var.cluster_id} elastic IP for API"
+  reverse_dns = "api.${var.exoscale_domain_name}"
 }
 resource "exoscale_domain_record" "api" {
   domain      = data.exoscale_domain.cluster.id
@@ -34,6 +35,7 @@ resource "exoscale_domain_record" "api" {
 resource "exoscale_elastic_ip" "ingress" {
   zone        = var.region
   description = "${var.cluster_id} elastic IP for ingress controller"
+  reverse_dns = "ingress.${var.exoscale_domain_name}"
 }
 resource "exoscale_domain_record" "ingress" {
   domain      = data.exoscale_domain.cluster.id
@@ -54,6 +56,7 @@ resource "exoscale_elastic_ip" "nat" {
   count       = var.cluster_network.enabled ? 1 : 0
   zone        = var.region
   description = "${var.cluster_id} elastic IP for NAT gateway"
+  reverse_dns = "egress.${var.exoscale_domain_name}"
 }
 resource "exoscale_domain_record" "egress" {
   count       = var.cluster_network.enabled ? 1 : 0


### PR DESCRIPTION
Since provider version v0.43.0, the `exoscale_elastic_ip` resource supports configuring reverse DNS again.

Provider update in #41 

See also #30 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
