### PR TITLE
vshn-lbaas-exoscale: Switch to new `exoscale_template` data source

### DIFF
--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -131,7 +131,7 @@ resource "exoscale_anti_affinity_group" "lb" {
   description = "${var.cluster_id} lb nodes"
 }
 
-data "exoscale_compute_template" "ubuntu2004" {
+data "exoscale_template" "ubuntu2004" {
   zone = var.region
   name = "Linux Ubuntu 20.04 LTS 64-bit"
 }
@@ -171,7 +171,7 @@ resource "exoscale_compute_instance" "lb" {
   name        = local.instance_fqdns[count.index]
   ssh_key     = var.ssh_key_name
   zone        = var.region
-  template_id = data.exoscale_compute_template.ubuntu2004.id
+  template_id = data.exoscale_template.ubuntu2004.id
   type        = var.lb_type
   disk_size   = 20
 


### PR DESCRIPTION
The `exoscale_compute_template` data source has been deprecated in favor of the `exoscale_template` data source.

With this change, the `vshn-lbaas-exoscale` module doesn't use any "compute-legacy" API endpoints anymore, which makes working with IAM v3 a bit easier.

Follow-up to #41 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
