### PR TITLE
vshn-lbaas-exoscale: Manage Floaty IAMv3 role and credentials in Terraform

### DIFF
--- a/modules/vshn-lbaas-exoscale/variables.tf
+++ b/modules/vshn-lbaas-exoscale/variables.tf
@@ -71,16 +71,6 @@ variable "control_vshn_net_token" {
   description = "The token is used to register the server with https://control.vshn.net/"
 }
 
-variable "lb_exoscale_api_key" {
-  type        = string
-  description = "API key for Floaty"
-}
-
-variable "lb_exoscale_api_secret" {
-  type        = string
-  description = "API secret for Floaty"
-}
-
 variable "hieradata_repo_user" {
   type        = string
   description = "User used to check out the hieradata git repo"


### PR DESCRIPTION
This PR introduces Terraform-managed IAMv3 credentials for Floaty on Exoscale. The IAMv3 role should be suitable for Floaty v1.1 and the future Floaty versions which will switch to Exoscale's compute v2 API.

Please note that this is a breaking change for clusters that were setup with or upgraded to terraform-modules v4. Operators will need to manually ensure that the old Terraform-managed Floaty credentials won't be invalidated before the new credentials are put in place on the LB VMs via VSHN's Puppet infrastructure.

We'll provide detailed instructions for the migration to terraform-modules v6 in the openshift4-terraform Commodore component.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
