### PR TITLE
vshn-lbaas-exoscale: Update LB security group to allow SSH to the LBs from anywhere

### DIFF
--- a/modules/vshn-lbaas-exoscale/security_groups.tf
+++ b/modules/vshn-lbaas-exoscale/security_groups.tf
@@ -14,6 +14,28 @@ resource "exoscale_security_group" "load_balancers" {
   description = "${var.cluster_id} load balancer VMs"
 }
 
+resource "exoscale_security_group_rule" "load_balancers_ssh_v4" {
+  security_group_id = exoscale_security_group.load_balancers.id
+
+  description = "SSH Access from anywhere on the LBs"
+  type        = "INGRESS"
+  protocol    = "TCP"
+  start_port  = "22"
+  end_port    = "22"
+  cidr        = "0.0.0.0/0"
+}
+
+resource "exoscale_security_group_rule" "load_balancers_ssh_v6" {
+  security_group_id = exoscale_security_group.load_balancers.id
+
+  description = "SSH Access from anywhere on the LBs"
+  type        = "INGRESS"
+  protocol    = "TCP"
+  start_port  = "22"
+  end_port    = "22"
+  cidr        = "::/0"
+}
+
 resource "exoscale_security_group_rule" "load_balancers_tcp4" {
   for_each = local.open_ports_tcp
 


### PR DESCRIPTION
We add explicit rules for SSH to the LBs in the LB security group as preparation for removing the SSH from anywhere rule from the `all_machines` security group in terraform-openshift4-exoscale.

See also https://github.com/appuio/terraform-openshift4-exoscale/issues/78

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
