### PR TITLE
vshn-lbaas-exoscale: Make LB disk size configurable

### DIFF
--- a/modules/vshn-lbaas-exoscale/main.tf
+++ b/modules/vshn-lbaas-exoscale/main.tf
@@ -173,7 +173,7 @@ resource "exoscale_compute_instance" "lb" {
   zone        = var.region
   template_id = data.exoscale_template.ubuntu2204.id
   type        = var.lb_type
-  disk_size   = 20
+  disk_size   = var.disk_size
 
   security_group_ids = concat(
     var.cluster_security_group_ids,

--- a/modules/vshn-lbaas-exoscale/variables.tf
+++ b/modules/vshn-lbaas-exoscale/variables.tf
@@ -121,3 +121,9 @@ variable "deploy_target_id" {
   default     = ""
   description = "ID of special deployment target, eg. dedicated hypervisors"
 }
+
+variable "disk_size" {
+  type        = number
+  default     = 20
+  description = "LB VM disk size"
+}


### PR DESCRIPTION
We still default to 20GB disks to make the change non-breaking.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
