### PR TITLE
Bump minimum required cloudscale Terraform provider to 5.0

### DIFF
--- a/modules/vshn-lbaas-cloudscale/README.md
+++ b/modules/vshn-lbaas-cloudscale/README.md
@@ -10,7 +10,7 @@ The Terraform module in this repository provisions all the infrastructure which 
 
 The module manages the VMs (cloud-init configs) and floating IPs for a highly-available OpenShift 4 cluster.
 
-The LB VMs run Ubuntu LTS 20.04 and are managed and configured via the VSHN Puppet infrastructure.
+The LB VMs run Ubuntu LTS 22.04 and are managed and configured via the VSHN Puppet infrastructure.
 Those VMs run HAproxy, keepalived, and [Floaty](https://github.com/vshn/floaty/) to provide a highly-available load balancer for the cluster.
 
 ### Module input variables

--- a/modules/vshn-lbaas-cloudscale/providers.tf
+++ b/modules/vshn-lbaas-cloudscale/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudscale = {
       source  = "cloudscale-ch/cloudscale"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/vshn-lbaas-exoscale/README.md
+++ b/modules/vshn-lbaas-exoscale/README.md
@@ -10,7 +10,7 @@ The Terraform module in this repository provisions all the infrastructure which 
 
 The module manages the VMs (cloud-init configs) and floating IPs for a highly-available OpenShift 4 cluster.
 
-The LB VMs run Ubuntu LTS 20.04 and are managed and configured via the VSHN Puppet infrastructure.
+The LB VMs run Ubuntu LTS 22.04 and are managed and configured via the VSHN Puppet infrastructure.
 Those VMs run HAproxy, keepalived, and [Floaty](https://github.com/vshn/floaty/) to provide a highly-available load balancer for the cluster.
 
 By default, the module expects that clusters on Exoscale are provisioned with public interfaces and access is managed with Exoscale security groups.


### PR DESCRIPTION
There's no breaking changes in the v5 provider which actually affect us.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
