### PR TITLE
vshn-lbaas-hieradata: Disable HAproxy in profile_openshift4_gateway when no VIPs configured

### DIFF
--- a/modules/vshn-lbaas-cloudscale/main.tf
+++ b/modules/vshn-lbaas-cloudscale/main.tf
@@ -13,7 +13,7 @@ resource "cloudscale_floating_ip" "api_vip" {
 }
 
 data "cloudscale_floating_ip" "api_vip" {
-  count       = var.use_existing_vips ? 1 : 0
+  count       = var.use_existing_vips && var.enable_api_vip ? 1 : 0
   ip_version  = 4
   reverse_ptr = "api.${var.node_name_suffix}"
 }
@@ -33,7 +33,7 @@ resource "cloudscale_floating_ip" "router_vip" {
 }
 
 data "cloudscale_floating_ip" "router_vip" {
-  count       = var.use_existing_vips ? 1 : 0
+  count       = var.use_existing_vips && var.enable_router_vip ? 1 : 0
   ip_version  = 4
   reverse_ptr = "ingress.${var.node_name_suffix}"
 }

--- a/modules/vshn-lbaas-hieradata/main.tf
+++ b/modules/vshn-lbaas-hieradata/main.tf
@@ -7,6 +7,8 @@ locals {
 
   public_interface   = var.cloud_provider == "cloudscale" ? "ens3" : "eth0"
   private_interfaces = var.cloud_provider == "cloudscale" ? ["ens4"] : ["eth1"]
+
+  enable_haproxy = var.api_vip != "" || var.internal_vip != "" || var.internal_router_vip != "" || var.router_vip != ""
 }
 
 resource "gitfile_checkout" "appuio_hieradata" {
@@ -44,6 +46,7 @@ resource "local_file" "lb_hieradata" {
       "enable_proxy_protocol" = var.enable_proxy_protocol
       "bootstrap_node"        = var.bootstrap_node
       "team"                  = var.team
+      "enable_haproxy"        = local.enable_haproxy
   })
 
   filename             = "${path.cwd}/appuio_hieradata/lbaas/${var.cluster_id}.yaml"

--- a/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
+++ b/modules/vshn-lbaas-hieradata/templates/hieradata.yaml.tmpl
@@ -14,6 +14,9 @@ profile_openshift4_gateway::private_interfaces:
 %{ for if in private_interfaces ~}
   - ${if}
 %{ endfor ~}
+%{ if !enable_haproxy ~}
+profile_openshift4_gateway::enable_haproxy: false
+%{ endif ~}
 profile_openshift4_gateway::floating_addresses:
 %{ if api_vip != "" ~}
   api: ${api_vip}


### PR DESCRIPTION
Replacement for #47. In contrast to the previous draft PR, this PR simply checks if the user has provided any HAProxy frontend IPs and sets `profile_openshift4_gateway::enable_haproxy=false` if no frontend IPs were provided.

To ensure minimum config churn, the change doesn't set `profile_openshift4_gateway::enable_haproxy=true` (which is the default value set by the Puppet profile) when at least one frontend IP is provided.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
